### PR TITLE
add show-welcome url argument for displays without input

### DIFF
--- a/ui/src/components/notification/welcome.tsx
+++ b/ui/src/components/notification/welcome.tsx
@@ -11,14 +11,18 @@ interface S {
 }
 
 class Welcome extends Component<{}, S> {
-  constructor() {
+  constructor(props) {
     super();
     const cookieValue = document.cookie.replace(
       /(?:(?:^|.*;\s*)showWelcome\s*\=\s*([^;]*).*$)|^.*$/,
       "$1"
     );
     this.state = {
-      showWelcome: cookieValue === "" ? true : false
+      showWelcome: !(
+        cookieValue === "" && props.matches["show-welcome"] === "0"
+      )
+        ? true
+        : false
     };
   }
 

--- a/ui/src/routes/home/index.tsx
+++ b/ui/src/routes/home/index.tsx
@@ -60,7 +60,7 @@ const ViewDefault = props => {
 const Home: preact.FunctionalComponent<homeProps> = props => {
   return (
     <div class="columns is-multiline">
-      <Welcome />
+      <Welcome {...props} />
       {isPrinting(props.printer_state) ? (
         <ViewProgress {...props} />
       ) : (


### PR DESCRIPTION
We want to show Prusa Connect on wall-mounted displays without any input method. We don't have any other way to set the showWelcome cookie either. This solution would work for us.