### PR TITLE
First Layer Exposure Time: step should be 1s, the same as touch-ui

### DIFF
--- a/src/printer/sl1/exposure.js
+++ b/src/printer/sl1/exposure.js
@@ -24,7 +24,7 @@ const config = {
   exposureTimeFirst: {
     text: translate("exp-times.layer-1st"),
     limit: [10, 120],
-    step: 0.1,
+    step: 1.0,
   },
   exposureTimeCalibration: {
     text: translate("exp-times.inc"),


### PR DESCRIPTION
Latest request is that the step for first layer exposure time should be 1 second, same as in touch-ui