### PR TITLE
Do not attempt digest re-authentication

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -76,7 +76,7 @@ const setUpAuth = () =>
               setUpAuth().then((data) => resolve(data))
             ); // ApiKey
           }
-          return setUpAuth().then((data) => resolve(data)); // http-digest
+          return null;
         } else {
           return response.json(); // done
         }

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,10 @@ window.onload = () => {
   });
 
   initAuth().then((version) => {
+    if (version == null) {
+      return;
+    }
+
     getJson("/api/printer").then((printerData) => {
       printer.init(version, printerData.data);
       setInterval(


### PR DESCRIPTION
Firefox does not display the auth dialog and fail all subsequent auth
attempts following a canceled one. This results in a endless flow of
failed auth errors. In case of just a wrong password the broser
re-opens the dialog on its own allowing the user to correct the
login name or password.

Fixes: SL1SW-1360